### PR TITLE
Disabling the symbols package generation

### DIFF
--- a/build/package.proj
+++ b/build/package.proj
@@ -14,7 +14,7 @@
 
     <ItemGroup>
       <ProjectFile Include="$(XdtRoot)/src/Microsoft.Web.XmlTransform/Microsoft.Web.XmlTransform.csproj" > 
-        <Properties>IncludeSymbols=true</Properties>
+        <Properties>IncludeSymbols=false</Properties>
       </ProjectFile>
     </ItemGroup>
 


### PR DESCRIPTION
Sign check is failing with symbols package generation. Disabling until the issue is fixed.