### PR TITLE
[source-build] A couple small source-build fixes.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
   <!-- Opt out of certain Arcade features -->
   <PropertyGroup>
     <UsingToolXliff>false</UsingToolXliff>
-    <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
+    <UsingToolNetFrameworkReferenceAssemblies Condition="'$(DotNetBuildFromSource)' != 'true'">true</UsingToolNetFrameworkReferenceAssemblies>
   </PropertyGroup>
   <PropertyGroup>
     <VersionPrefix>3.0.1</VersionPrefix>

--- a/src/Microsoft.Web.XmlTransform/Microsoft.Web.XmlTransform.csproj
+++ b/src/Microsoft.Web.XmlTransform/Microsoft.Web.XmlTransform.csproj
@@ -3,7 +3,8 @@
   <Import Project="$(RepositoryEngineeringDir)\Package.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' != 'true'">$(TargetFrameworks);net40</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <IsPackable>true</IsPackable>
     <IsShipping>false</IsShipping>

--- a/test/Microsoft.Web.XmlTransform.Test/Microsoft.Web.XmlTransform.Test.csproj
+++ b/test/Microsoft.Web.XmlTransform.Test/Microsoft.Web.XmlTransform.Test.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Don't build for .NET FX.  This allows source-build to remove the dependency on the prebuilt reference assemblies.
- Don't build a test project in source-build.

cc @NikolaMilosavljevic