### PR TITLE
Fix NullReference exception in XmlTransformationLogger when using 'RemoveAttributes'

### DIFF
--- a/src/Microsoft.Web.XmlTransform/XmlTransformationLogger.cs
+++ b/src/Microsoft.Web.XmlTransform/XmlTransformationLogger.cs
@@ -212,7 +212,7 @@ namespace Microsoft.Web.XmlTransform
                 uri = errorInfoDocument.FileName;
             }
             else {
-                uri = errorInfoDocument.BaseURI;
+                uri = xmlDocument.BaseURI;
             }
 
             return ConvertUriToFileName(uri);


### PR DESCRIPTION
Fix typo in XmlTransformationLogger which is causing some failures in VSTS / Azure DevOps pipeline transforms, test included.